### PR TITLE
expose getTargetAppNames to the public API

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -3,12 +3,14 @@ import StatsigStorageExample from "./examples/StatsigStorageExample";
 import { StatsigInterface } from "./src/interfaces/StatsigInterface";
 import { StorageInterface } from "./src/interfaces/StorageInterface";
 import { ConfigSpecs } from "./src/types/ConfigSpecs";
+import { TargetAppNames } from "./src/types/TargetAppNames";
 
 export {
   StatsigStorageExample,
   StatsigInterface,
   StorageInterface,
-  ConfigSpecs
+  ConfigSpecs,
+  TargetAppNames
 };
 
 export default StatsigOnPrem

--- a/src/StatsigOnPrem.ts
+++ b/src/StatsigOnPrem.ts
@@ -20,6 +20,7 @@ import SpecsCache from "./SpecsCache";
 import StorageHandler from "./utils/StorageHandler";
 import CacheUtils from "./utils/CacheUtils";
 import HashUtils from "./utils/HashUtils";
+import { TargetAppNames } from "./types/TargetAppNames";
 
 export default class StatsigOnPrem implements StatsigInterface {
   private store: StorageHandler;
@@ -342,6 +343,10 @@ export default class StatsigOnPrem implements StatsigInterface {
     if (targetApp) {
       await this.cache.clear(CacheUtils.getCacheKey(targetApp));
     }
+  }
+
+  public async getTargetAppNames(): Promise<TargetAppNames> {
+    return this.store.getTargetAppNames();
   }
 
   /* SDK Keys */

--- a/src/utils/StorageHandler.ts
+++ b/src/utils/StorageHandler.ts
@@ -208,6 +208,15 @@ export default class StorageHandler {
       : null;
   }
 
+  public async getTargetAppNames(): Promise<TargetAppNames> {
+    const serialized = await this.storage.get(
+      StorageUtils.getStorageKey(StorageKeyType.TargetAppNames)
+    );
+    return serialized
+      ? StorageUtils.deserializeSets<TargetAppNames>(serialized)
+      : new Set();
+  }
+
   private async updateEntityAssocs(
     entities: Partial<EntityNames>,
     mutation: MutationType,
@@ -339,15 +348,6 @@ export default class StorageHandler {
       )
     );
     await this.removeEntityAssocs(entityNames);
-  }
-
-  private async getTargetAppNames(): Promise<TargetAppNames> {
-    const serialized = await this.storage.get(
-      StorageUtils.getStorageKey(StorageKeyType.TargetAppNames)
-    );
-    return serialized
-      ? StorageUtils.deserializeSets<TargetAppNames>(serialized)
-      : new Set();
   }
 
   private async updateTargetAppNames(

--- a/tests/TargetApps.test.ts
+++ b/tests/TargetApps.test.ts
@@ -82,4 +82,30 @@ describe("Target Apps", () => {
       },
     });
   });
+
+  it("Get list of Target Apps after creation", async () => {
+    await statsig.createTargetApp("serverApp", {
+      gates: new Set(["gate_1"]),
+      configs: new Set(["config_1"]),
+      experiments: new Set(["exp_1"]),
+    });
+    await statsig.createTargetApp("clientApp", {
+      gates: new Set(["gate_2"]),
+      configs: new Set(["config_2"]),
+      experiments: new Set(["exp_2"]),
+    });
+    const targetAppNames = await statsig.getTargetAppNames();
+    expect(targetAppNames).toEqual(new Set(["serverApp", "clientApp"]))
+  });
+
+  it("Get list of Target Apps after deletion", async () => {
+    await statsig.createTargetApp("serverApp", {
+      gates: new Set(["gate_1"]),
+      configs: new Set(["config_1"]),
+      experiments: new Set(["exp_1"]),
+    });
+    await statsig.deleteTargetApp("serverApp");
+    const targetAppNames = await statsig.getTargetAppNames();
+    expect(targetAppNames).toEqual(new Set())
+  });
 });


### PR DESCRIPTION
This PR exposes the `getTargetAppNames` method from `StorageHandler` to the public `StatsigOnPrem` API. 

This will provide a way for us to confirm whether an app has been onboarded. We mostly wish to access this method so that we can run some custom validation when association entities to target apps, where we first assert that the target app exists before creating the association.