### PR TITLE
Handle empty cache scenarios

### DIFF
--- a/src/SDKKeysCache.ts
+++ b/src/SDKKeysCache.ts
@@ -1,12 +1,12 @@
 import { SDKKeysCacheInterface } from "./interfaces/SDKKeyCacheInterface";
 
 export default class SDKKeysCache implements SDKKeysCacheInterface {
-  private cache: Set<string>;
+  private cache: Set<string> | null;
   public constructor() {
-    this.cache = new Set();
+    this.cache = null;
   }
 
-  get(): Promise<Set<string>> {
+  get(): Promise<Set<string> | null> {
     return Promise.resolve(this.cache);
   }
   set(keys: Set<string>): Promise<void> {
@@ -14,7 +14,7 @@ export default class SDKKeysCache implements SDKKeysCacheInterface {
     return Promise.resolve();
   }
   clear(): Promise<void> {
-    this.cache.clear();
+    this.cache = null;
     return Promise.resolve();
   }
 }

--- a/src/SpecsCache.ts
+++ b/src/SpecsCache.ts
@@ -7,8 +7,8 @@ export default class SpecsCache implements SpecsCacheInterface {
     this.cache = {};
   }
 
-  get(key: string): Promise<ConfigSpecs> {
-    return Promise.resolve(this.cache[key]);
+  get(key: string): Promise<ConfigSpecs | null> {
+    return Promise.resolve(this.cache[key] ?? null);
   }
   set(key: string, specs: ConfigSpecs): Promise<void> {
     this.cache[key] = specs;

--- a/src/StatsigOnPrem.ts
+++ b/src/StatsigOnPrem.ts
@@ -521,6 +521,13 @@ export default class StatsigOnPrem implements StatsigInterface {
   }
 
   public async getRegisteredSDKKeys(): Promise<Set<string>> {
-    return this.cache.getSDKKeys();
+    const cachedKeys = await this.cache.getSDKKeys();
+    if (cachedKeys) {
+      return cachedKeys;
+    }
+
+    const sdkKeys = await this.store.getRegisteredSDKKeys();
+    await this.cache.cacheSDKKeys(sdkKeys);
+    return sdkKeys;
   }
 }

--- a/src/interfaces/SDKKeyCacheInterface.ts
+++ b/src/interfaces/SDKKeyCacheInterface.ts
@@ -5,9 +5,9 @@
  */
 export interface SDKKeysCacheInterface {
   /**
-   * Returns SDK keys.
+   * Returns SDK keys, or null if the cache has not been populated yet.
    */
-  get(): Promise<Set<string>>;
+  get(): Promise<Set<string> | null>;
   /**
    * Updates SDK keys.
    * @param keys - Set of SDK keys to store

--- a/src/interfaces/SpecsCacheInterface.ts
+++ b/src/interfaces/SpecsCacheInterface.ts
@@ -7,10 +7,10 @@ import { ConfigSpecs } from "../types/ConfigSpecs";
  */
 export interface SpecsCacheInterface {
   /**
-   * Returns specs stored for a given key.
+   * Returns specs stored for a given key, or null if the cache has not been populated yet.
    * @param key - Key of stored specs
    */
-  get(key: string): Promise<ConfigSpecs>;
+  get(key: string): Promise<ConfigSpecs | null>;
   /**
    * Updates specs for a given key.
    * @param key - Key of stored specs

--- a/src/utils/CacheHandler.ts
+++ b/src/utils/CacheHandler.ts
@@ -21,7 +21,7 @@ export default class CacheHandler {
     await this.cache.specs.set(cacheKey, specs);
   }
 
-  public async getSpecs(sdkKey: string): Promise<ConfigSpecs> {
+  public async getSpecs(sdkKey: string): Promise<ConfigSpecs | null> {
     const cacheKey = CacheUtils.getCacheKey(sdkKey);
     return await this.cache.specs.get(cacheKey);
   }
@@ -43,7 +43,7 @@ export default class CacheHandler {
     return await this.cache.keys.set(sdkKeys);
   }
 
-  public async getSDKKeys(): Promise<Set<string>> {
+  public async getSDKKeys(): Promise<Set<string> | null> {
     return await this.cache.keys.get();
   }
 

--- a/tests/SDKKeysCachePlugin.test.ts
+++ b/tests/SDKKeysCachePlugin.test.ts
@@ -19,19 +19,32 @@ describe("SDKKeysCachePlugin", () => {
   it("Register SDK Key", async () => {
     await statsig.registerSDKKey("secret-123");
     const cachedKeys = await sdkKeysCache.get();
-    expect(cachedKeys.has("secret-123")).toEqual(true);
+    expect(cachedKeys).not.toBeNull();
+    expect(cachedKeys?.has("secret-123")).toEqual(true);
   });
 
   it("Deactivate SDK Key", async () => {
     await statsig.deactivateSDKKey("secret-123");
     const cachedKeys = await sdkKeysCache.get();
-    expect(cachedKeys.has("secret-123")).toEqual(false);
+    expect(cachedKeys).not.toBeNull();
+    expect(cachedKeys?.has("secret-123")).toEqual(false);
   });
 
   it("Clear Cache", async () => {
     await statsig.registerSDKKey("secret-123");
     await statsig.clearCache();
     const cachedKeys = await sdkKeysCache.get();
-    expect(cachedKeys.has("secret-123")).toEqual(false);
+    expect(cachedKeys).toBeNull();
+  });
+
+  it("Re-populates from the store", async () => {
+    await statsig.registerSDKKey("secret-123");
+    await sdkKeysCache.clear();
+    const registeredKeys = await statsig.getRegisteredSDKKeys();
+    expect(registeredKeys.has("secret-123")).toEqual(true);
+    
+    const cachedKeys = await sdkKeysCache.get();
+    expect(cachedKeys).not.toBeNull();
+    expect(cachedKeys?.has("secret-123")).toEqual(true);
   });
 });


### PR DESCRIPTION
This PR handles scenarios where the cache has not yet been populated, or has been cleared, and the store still has the requested data:
* Changed the cache interfaces to allow `null` to be returned to indicate cache miss. 
* Modified `getRegisteredSDKKeys` implementation to read from the store when the cache returns a null
   * This was not necessary for `getConfigSpecs` as the null value is [already handled](https://github.com/crobertson-atl/statsig-on-prem/blob/main/src/StatsigOnPrem.ts#L85-L88) 