### PR TITLE
Add an updateFeatureGates bulk method

### DIFF
--- a/tests/FeatureGateTest.test.ts
+++ b/tests/FeatureGateTest.test.ts
@@ -44,6 +44,42 @@ describe("Feature Gate", () => {
     StatsigSDK.shutdown();
   });
 
+  it("Update Gates", async () => {
+    await statsig.createGate("test-gate1", { enabled: true });
+    await statsig.createGate("test-gate2", { enabled: true });
+    await statsig.createGate("test-gate3", { enabled: false });
+    await statsig.createGate("test-target-app-gate", { targetApps: ['target-app'], enabled: false });
+
+    const results = await statsig.updateGates([
+      { name: "test-gate1", args: { enabled: false }},
+      // Skip test-gate2
+      { name: "test-gate3", args: { enabled: true }},
+      { name: "test-target-app-gate", args: { enabled: false }},
+      { name: "non-existent-gate", args: { enabled: true }},
+    ]);
+    const configSpecs = await statsig.getConfigSpecs(sdkKey);
+    await StatsigSDK.initialize("secret-key", {
+      bootstrapValues: JSON.stringify(configSpecs),
+    });
+    expect(StatsigSDK.checkGateSync({ userID: "123" }, "test-gate1")).toEqual(
+      false
+    );
+    expect(StatsigSDK.checkGateSync({ userID: "123" }, "test-gate2")).toEqual(
+      true
+    );
+    expect(StatsigSDK.checkGateSync({ userID: "123" }, "test-gate3")).toEqual(
+      true
+    );
+    expect(results).toMatchObject([
+      { name: 'test-gate1', status: 'success' },
+      { name: 'test-gate3', status: 'success' },
+      { name: 'test-target-app-gate', status: 'success' },
+      { name: 'non-existent-gate', status: 'non-existent' },
+    ])
+    StatsigSDK.shutdown();
+  });
+
+
   it("Delete Gate", async () => {
     await statsig.createGate("test-gate", { enabled: true });
     await statsig.deleteGate("test-gate");


### PR DESCRIPTION
Add a new updateFeatureGates that takes an array of gate name and update args and then updates them all in one go.
The intention for this is to reduce the amount of wait time for a consumer to update a batch of gates one by one.