### PR TITLE
Support generating config specs for SSR with target app lookup

### DIFF
--- a/src/Errors.ts
+++ b/src/Errors.ts
@@ -3,3 +3,7 @@ export class ExhaustSwitchError extends Error {
     super(`Unreachable case: ${JSON.stringify(x)}`);
   }
 }
+
+export function assertNeverX(x: never): never {
+  throw new ExhaustSwitchError(x);
+}

--- a/src/utils/CacheHandler.ts
+++ b/src/utils/CacheHandler.ts
@@ -4,6 +4,7 @@ import SDKKeysCache from "../SDKKeysCache";
 import SpecsCache from "../SpecsCache";
 import { ConfigSpecs } from "../types/ConfigSpecs";
 import CacheUtils from "./CacheUtils";
+import { ConfigSpecsOptions } from "./ConfigSpecsUtils";
 
 type CacheLibrary = { specs: SpecsCacheInterface; keys: SDKKeysCacheInterface };
 
@@ -16,13 +17,20 @@ export default class CacheHandler {
     };
   }
 
-  public async cacheSpecs(sdkKey: string, specs: ConfigSpecs): Promise<void> {
-    const cacheKey = CacheUtils.getCacheKey(sdkKey);
+  public async cacheSpecs(
+    sdkKey: string,
+    options: ConfigSpecsOptions | undefined,
+    specs: ConfigSpecs
+  ): Promise<void> {
+    const cacheKey = CacheUtils.getCacheKey(sdkKey, options);
     await this.cache.specs.set(cacheKey, specs);
   }
 
-  public async getSpecs(sdkKey: string): Promise<ConfigSpecs | null> {
-    const cacheKey = CacheUtils.getCacheKey(sdkKey);
+  public async getSpecs(
+    sdkKey: string,
+    options: ConfigSpecsOptions | undefined
+  ): Promise<ConfigSpecs | null> {
+    const cacheKey = CacheUtils.getCacheKey(sdkKey, options);
     return await this.cache.specs.get(cacheKey);
   }
 

--- a/src/utils/CacheUtils.ts
+++ b/src/utils/CacheUtils.ts
@@ -1,7 +1,27 @@
+import { ConfigSpecsOptions } from "./ConfigSpecsUtils";
 import HashUtils from "./HashUtils";
 
 export default class CacheUtils {
-  public static getCacheKey(sdkKey: string) {
-    return HashUtils.hashString(sdkKey);
+  public static getCacheKey(sdkKey: string, options?: ConfigSpecsOptions) {
+    let cacheKey = sdkKey;
+    if (options?.ssr) {
+      cacheKey = `{sdk_key:${sdkKey}}`;
+      const { clientKeys, targetApps } = options?.ssr;
+      if (clientKeys) {
+        cacheKey = `${cacheKey}:{${
+          clientKeys === "all"
+            ? "client_keys:all"
+            : `client_keys:${clientKeys.join()}`
+        }}`;
+      }
+      if (targetApps) {
+        cacheKey = `${cacheKey}:{${
+          targetApps === "all"
+            ? "target_apps:all"
+            : `target_apps:${targetApps.join()}`
+        }}`;
+      }
+    }
+    return HashUtils.hashString(cacheKey);
   }
 }

--- a/src/utils/ConfigSpecsUtils.ts
+++ b/src/utils/ConfigSpecsUtils.ts
@@ -1,10 +1,22 @@
 import EntityDynamicConfig from "../entities/EntityDynamicConfig";
 import EntityFeatureGate from "../entities/EntityFeatureGate";
 import EntityExperiment from "../entities/EntityExperiment";
-import {
+import type {
   APIConfigSpec,
+  APIEntityNames,
   ConfigSpecs,
 } from "../types/ConfigSpecs";
+import HashUtils from "./HashUtils";
+import { filterNulls } from "./filterNulls";
+import type { EntityNames } from "../types/EntityNames";
+import StorageHandler from "./StorageHandler";
+
+export type ConfigSpecsOptions = { ssr?: SSROptions };
+
+export type SSROptions = {
+  targetApps?: string[] | "all";
+  clientKeys?: string[] | "all";
+};
 
 export default class ConfigSpecsUtils {
   public static getEmptyConfigSpecs(): ConfigSpecs {
@@ -34,5 +46,81 @@ export default class ConfigSpecsUtils {
         entity instanceof EntityExperiment ? entity.getIsActive() : undefined,
       entity: entity.getAPIEntity(),
     };
+  }
+
+  public static async getHashedSDKKeysToEntities(
+    store: StorageHandler,
+    options: SSROptions
+  ): Promise<Record<string, APIEntityNames>> {
+    const getEntitiesFromKey = async (
+      key: string
+    ): Promise<EntityNames | null> => {
+      const targetApps = await store.getTargetAppsFromSDKKey(key);
+      if (targetApps == null) {
+        return null;
+      }
+      return await store.getEntityAssocsForMultipleTargetApps(targetApps);
+    };
+
+    const getEntitiesFromTargetApp = async (
+      targetApp: string
+    ): Promise<EntityNames | null> => {
+      return await store.getEntityAssocs(targetApp);
+    };
+
+    let mappings: {
+      source: string;
+      load: (source: string) => Promise<EntityNames | null>;
+    }[] = [];
+
+    if (options.clientKeys) {
+      const keys =
+        options.clientKeys === "all"
+          ? Array.from(await store.getRegisteredSDKKeys())
+          : options.clientKeys;
+      mappings = mappings.concat(
+        keys.map((key) => ({
+          source: key,
+          load: getEntitiesFromKey,
+        }))
+      );
+    }
+    if (options.targetApps) {
+      const targetApps =
+        options.targetApps === "all"
+          ? Array.from(await store.getTargetAppNames())
+          : options.targetApps;
+      mappings = mappings.concat(
+        targetApps.map((targetApp) => ({
+          source: targetApp,
+          load: getEntitiesFromTargetApp,
+        }))
+      );
+    }
+
+    return Object.fromEntries(
+      new Map(
+        filterNulls(
+          await Promise.all(
+            mappings.map(async ({ source, load }) => {
+              const entities = await load(source);
+              if (entities == null) {
+                return null;
+              }
+              return [
+                HashUtils.hashString(source),
+                {
+                  gates: Array.from(entities.gates),
+                  configs: [
+                    ...Array.from(entities.configs),
+                    ...Array.from(entities.experiments),
+                  ],
+                },
+              ];
+            })
+          )
+        )
+      )
+    );
   }
 }

--- a/tests/TargetApps.test.ts
+++ b/tests/TargetApps.test.ts
@@ -81,10 +81,26 @@ describe("Target Apps", () => {
     await statsig.registerSDKKey("server-key");
     await statsig.registerSDKKey("client-key");
     await statsig.assignTargetAppsToSDKKey(["clientApp"], "client-key");
-    const configSpecs = await statsig.getConfigSpecs("server-key");
+
+    // Lookup via client keys
+    let configSpecs = await statsig.getConfigSpecs("server-key", {
+      ssr: { clientKeys: ["client-key"] },
+    });
     const hashedClientKey = HashUtils.hashString("client-key");
     expect(configSpecs.hashed_sdk_keys_to_entities).toEqual({
       [hashedClientKey]: {
+        gates: ["gate_1"],
+        configs: ["config_1", "exp_1"],
+      },
+    });
+
+    // Lookup via target apps
+    configSpecs = await statsig.getConfigSpecs("server-key", {
+      ssr: { targetApps: ["clientApp"] },
+    });
+    const hashedTargetApp = HashUtils.hashString("clientApp");
+    expect(configSpecs.hashed_sdk_keys_to_entities).toEqual({
+      [hashedTargetApp]: {
         gates: ["gate_1"],
         configs: ["config_1", "exp_1"],
       },

--- a/tests/__snapshots__/DynamicConfig.test.ts.snap
+++ b/tests/__snapshots__/DynamicConfig.test.ts.snap
@@ -66,7 +66,6 @@ exports[`Dynamic Config Update Dynmaic Config Rules: config-rules 1`] = `
   ],
   "feature_gates": [],
   "has_updates": true,
-  "hashed_sdk_keys_to_entities": {},
   "layer_configs": [],
   "layers": {},
   "time": Any<Number>,


### PR DESCRIPTION
Allow generating config specs with target app to entity mapping for SSR. Note that the function takes in target app names, but the mapping will use the target app "ID" (hashed target app name) as the key
`StatsigOnPrem.getConfigSpecs("server-key", {
      ssr: { targetApps: ["clientApp"] },
    })`

Expose internal function `getTargetAppsFromSDKKey` to better enable using the method above
`const targetApps = StatsigOnPrem.getTargetAppNames("client-key")`
`StatsigOnPrem.getConfigSpecs("server-key", {
      ssr: { targetApps: Array.from(targetApps) }
    })`