### PR TITLE
Reduce storage sets in update gate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "statsig-on-prem",
-  "version": "0.0.0-beta.9",
+  "version": "0.0.0-beta.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "statsig-on-prem",
-      "version": "0.0.0-beta.9",
+      "version": "0.0.0-beta.10",
       "license": "ISC",
       "dependencies": {
         "uuid": "^9.0.1",

--- a/src/utils/StorageHandler.ts
+++ b/src/utils/StorageHandler.ts
@@ -38,7 +38,7 @@ export default class StorageHandler {
   ): Promise<void> {
     const { targetApps, ...changes } = args;
     let updated: FeatureGate = { ...gate, ...changes };
-    if (targetApps && targetApps.length > 0) {
+    if (targetApps) {
       await this.updateGateTargetApps(
         updated,
         new Set(targetApps),

--- a/src/utils/StorageHandler.ts
+++ b/src/utils/StorageHandler.ts
@@ -551,16 +551,14 @@ export default class StorageHandler {
       const impactedTargetApps = new Set(entity.targetApps);
       targetApps.forEach(value => allTargetApps.has(value) && impactedTargetApps.add(value));
       await Promise.all(
-        Array.from(impactedTargetApps).reduce<Promise<void>[]>(
-          (targetAppPromises, targetApp) => {
-            if (targetApps.has(targetApp) && !entity.targetApps.has(targetApp)) {
-              targetAppPromises.push(this.addEntityAssocs(entityNames, targetApp));
-            } else if (!targetApps.has(targetApp) && entity.targetApps.has(targetApp)) {
-              targetAppPromises.push(this.removeEntityAssocs(entityNames, targetApp));
-            }
-            return targetAppPromises;
-          },
-          []
+        filterNulls(
+          Array.from(allTargetApps).map((targetApp) =>
+            targetApps.has(targetApp)
+              ? this.addEntityAssocs(entityNames, targetApp)
+              : entity.targetApps.has(targetApp)
+              ? this.removeEntityAssocs(entityNames, targetApp)
+              : null
+          )
         )
       );
       entity.targetApps = targetApps;

--- a/src/utils/StorageHandler.ts
+++ b/src/utils/StorageHandler.ts
@@ -547,8 +547,9 @@ export default class StorageHandler {
         );
       }
     } else {
+      const allTargetApps = await this.getTargetAppNames();
       const impactedTargetApps = new Set(entity.targetApps);
-      targetApps.forEach(value => impactedTargetApps.add(value));
+      targetApps.forEach(value => allTargetApps.has(value) && impactedTargetApps.add(value));
       await Promise.all(
         Array.from(impactedTargetApps).reduce<Promise<void>[]>(
           (targetAppPromises, targetApp) => {

--- a/src/utils/StorageHandler.ts
+++ b/src/utils/StorageHandler.ts
@@ -548,8 +548,6 @@ export default class StorageHandler {
       }
     } else {
       const allTargetApps = await this.getTargetAppNames();
-      const impactedTargetApps = new Set(entity.targetApps);
-      targetApps.forEach(value => allTargetApps.has(value) && impactedTargetApps.add(value));
       await Promise.all(
         filterNulls(
           Array.from(allTargetApps).map((targetApp) =>

--- a/tests/FeatureGateTest.test.ts
+++ b/tests/FeatureGateTest.test.ts
@@ -107,5 +107,32 @@ describe("Feature Gate", () => {
       expect(storageSpy.set).toHaveBeenCalledTimes(2);
     });
 
+    it("update gate should not update target apps if none were associated", async () => {
+      await statsig.createGate("test-gate", { enabled: true });
+      storageSpy.set.mockClear();
+
+      await statsig.updateGate("test-gate", { enabled: false });
+      expect(storageSpy.set).toHaveBeenNthCalledWith(1, expect.stringMatching('statsig:gate:*'), expect.anything())
+      expect(storageSpy.set).toHaveBeenCalledTimes(1);
+    });
+
+    it("update gate should not update target apps if update target apps arg is empty and no prior target app", async () => {
+      await statsig.createGate("test-gate", { enabled: true });
+      storageSpy.set.mockClear();
+
+      await statsig.updateGate("test-gate", { enabled: false, targetApps: [] });
+      expect(storageSpy.set).toHaveBeenNthCalledWith(1, expect.stringMatching('statsig:gate:*'), expect.anything())
+      expect(storageSpy.set).toHaveBeenCalledTimes(1);
+    });
+
+    it("update gate should remove target app if update target apps arg is empty and there is a prior target app", async () => {
+      await statsig.createGate("test-gate", { enabled: true, targetApps: ["target_app"] });
+      storageSpy.set.mockClear();
+
+      await statsig.updateGate("test-gate", { enabled: false, targetApps: [] });
+      expect(storageSpy.set).toHaveBeenNthCalledWith(1, expect.stringMatching('statsig:entities:*'), expect.anything())
+      expect(storageSpy.set).toHaveBeenNthCalledWith(2, expect.stringMatching('statsig:gate:*'), expect.anything())
+      expect(storageSpy.set).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/tests/FeatureGateTest.test.ts
+++ b/tests/FeatureGateTest.test.ts
@@ -77,7 +77,7 @@ describe("Feature Gate", () => {
     expect(gate?.targetApps).toEqual(new Set());
   });
 
-  describe("multi-target app storage", () => {
+  describe("Update Gate interactions with storage", () => {
     let storageSpy: { [key: string]: jest.SpyInstance };
     beforeEach(async () => {
       const emptyTargetApp = {
@@ -90,9 +90,9 @@ describe("Feature Gate", () => {
       await statsig.createTargetApp("target_app", emptyTargetApp);
 
       storageSpy = {
-        set: jest.spyOn(storage, 'set'),
-        get: jest.spyOn(storage, 'get'),
-        delete: jest.spyOn(storage, 'delete'),
+        set: jest.spyOn(storage, "set"),
+        get: jest.spyOn(storage, "get"),
+        delete: jest.spyOn(storage, "delete"),
       };
 
     });
@@ -102,8 +102,8 @@ describe("Feature Gate", () => {
       storageSpy.set.mockClear();
 
       await statsig.updateGate("test-gate", { targetApps: ["target_app"] });
-      expect(storageSpy.set).toHaveBeenNthCalledWith(1, expect.stringMatching('statsig:entities:*'), expect.anything())
-      expect(storageSpy.set).toHaveBeenNthCalledWith(2, expect.stringMatching('statsig:gate:*'), expect.anything())
+      expect(storageSpy.set).toHaveBeenNthCalledWith(1, expect.stringMatching("statsig:entities:*"), expect.anything())
+      expect(storageSpy.set).toHaveBeenNthCalledWith(2, expect.stringMatching("statsig:gate:*"), expect.anything())
       expect(storageSpy.set).toHaveBeenCalledTimes(2);
     });
 
@@ -112,7 +112,7 @@ describe("Feature Gate", () => {
       storageSpy.set.mockClear();
 
       await statsig.updateGate("test-gate", { enabled: false });
-      expect(storageSpy.set).toHaveBeenNthCalledWith(1, expect.stringMatching('statsig:gate:*'), expect.anything())
+      expect(storageSpy.set).toHaveBeenNthCalledWith(1, expect.stringMatching("statsig:gate:*"), expect.anything())
       expect(storageSpy.set).toHaveBeenCalledTimes(1);
     });
 
@@ -121,7 +121,7 @@ describe("Feature Gate", () => {
       storageSpy.set.mockClear();
 
       await statsig.updateGate("test-gate", { enabled: false, targetApps: [] });
-      expect(storageSpy.set).toHaveBeenNthCalledWith(1, expect.stringMatching('statsig:gate:*'), expect.anything())
+      expect(storageSpy.set).toHaveBeenNthCalledWith(1, expect.stringMatching("statsig:gate:*"), expect.anything())
       expect(storageSpy.set).toHaveBeenCalledTimes(1);
     });
 
@@ -130,9 +130,18 @@ describe("Feature Gate", () => {
       storageSpy.set.mockClear();
 
       await statsig.updateGate("test-gate", { enabled: false, targetApps: [] });
-      expect(storageSpy.set).toHaveBeenNthCalledWith(1, expect.stringMatching('statsig:entities:*'), expect.anything())
-      expect(storageSpy.set).toHaveBeenNthCalledWith(2, expect.stringMatching('statsig:gate:*'), expect.anything())
+      expect(storageSpy.set).toHaveBeenNthCalledWith(1, expect.stringMatching("statsig:entities:*"), expect.anything())
+      expect(storageSpy.set).toHaveBeenNthCalledWith(2, expect.stringMatching("statsig:gate:*"), expect.anything())
       expect(storageSpy.set).toHaveBeenCalledTimes(2);
+    });
+
+    it("update gate should only update existing target apps", async () => {
+      await statsig.createGate("test-gate", { enabled: true });
+      storageSpy.set.mockClear();
+
+      await statsig.updateGate("test-gate", { enabled: false, targetApps: ["non-existent-target-app"] });
+      expect(storageSpy.set).toHaveBeenNthCalledWith(1, expect.stringMatching("statsig:gate:*"), expect.anything())
+      expect(storageSpy.set).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/tests/FeatureGateTest.test.ts
+++ b/tests/FeatureGateTest.test.ts
@@ -17,6 +17,7 @@ describe("Feature Gate", () => {
   afterEach(async () => {
     storage.clearAll();
     await statsig.clearCache();
+    jest.clearAllMocks();
   });
 
   it("Create Gate", async () => {
@@ -74,5 +75,37 @@ describe("Feature Gate", () => {
     await statsig.removeTargetAppsFromGate("test-gate", ["target-app-1"]);
     gate = await statsig.getGate("test-gate");
     expect(gate?.targetApps).toEqual(new Set());
+  });
+
+  describe("multi-target app storage", () => {
+    let storageSpy: { [key: string]: jest.SpyInstance };
+    beforeEach(async () => {
+      const emptyTargetApp = {
+        gates: new Set([]),
+        configs: new Set([]),
+        experiments: new Set([]),
+      };
+      await statsig.createTargetApp("irrelevant_target_app", emptyTargetApp);
+      await statsig.createTargetApp("irrelevant_target_app2", emptyTargetApp);
+      await statsig.createTargetApp("target_app", emptyTargetApp);
+
+      storageSpy = {
+        set: jest.spyOn(storage, 'set'),
+        get: jest.spyOn(storage, 'get'),
+        delete: jest.spyOn(storage, 'delete'),
+      };
+
+    });
+
+    it("update gate should only update storage for impacted target apps", async () => {
+      await statsig.createGate("test-gate", { enabled: true });
+      storageSpy.set.mockClear();
+
+      await statsig.updateGate("test-gate", { targetApps: ["target_app"] });
+      expect(storageSpy.set).toHaveBeenNthCalledWith(1, expect.stringMatching('statsig:entities:*'), expect.anything())
+      expect(storageSpy.set).toHaveBeenNthCalledWith(2, expect.stringMatching('statsig:gate:*'), expect.anything())
+      expect(storageSpy.set).toHaveBeenCalledTimes(2);
+    });
+
   });
 });


### PR DESCRIPTION
When updating a gate only iterate through and update the targetApps affected by the update, rather than all target apps.