### PR TITLE
Fix clearing specs cache with SSR option

### DIFF
--- a/src/SpecsCache.ts
+++ b/src/SpecsCache.ts
@@ -2,20 +2,30 @@ import { SpecsCacheInterface } from "./interfaces/SpecsCacheInterface";
 import { ConfigSpecs } from "./types/ConfigSpecs";
 
 export default class SpecsCache implements SpecsCacheInterface {
-  private cache: Record<string, ConfigSpecs>;
+  private cache: Record<string, Record<string, ConfigSpecs>>;
   public constructor() {
     this.cache = {};
   }
 
-  get(key: string): Promise<ConfigSpecs | null> {
-    return Promise.resolve(this.cache[key] ?? null);
+  get(key: string, field: string): Promise<ConfigSpecs | null> {
+    if (!(key in this.cache)) {
+      return Promise.resolve(null);
+    }
+    return Promise.resolve(this.cache[key][field] ?? null);
   }
-  set(key: string, specs: ConfigSpecs): Promise<void> {
-    this.cache[key] = specs;
+  set(key: string, field: string, specs: ConfigSpecs): Promise<void> {
+    if (!(key in this.cache)) {
+      this.cache[key] = {};
+    }
+    this.cache[key][field] = specs;
     return Promise.resolve();
   }
-  clear(key: string): Promise<void> {
-    delete this.cache[key];
+  clear(key: string, field?: string): Promise<void> {
+    if (field && key in this.cache) {
+      delete this.cache[key][field];
+    } else {
+      delete this.cache[key];
+    }
     return Promise.resolve();
   }
   clearAll(): Promise<void> {

--- a/src/interfaces/SpecsCacheInterface.ts
+++ b/src/interfaces/SpecsCacheInterface.ts
@@ -8,20 +8,28 @@ import { ConfigSpecs } from "../types/ConfigSpecs";
 export interface SpecsCacheInterface {
   /**
    * Returns specs stored for a given key, or null if the cache has not been populated yet.
-   * @param key - Key of stored specs
+   * @param key - Primary key of stored specs
+   * @param field - Secondary key of stored specs
    */
-  get(key: string): Promise<ConfigSpecs | null>;
+  get(key: string, field: string): Promise<ConfigSpecs | null>;
   /**
    * Updates specs for a given key.
-   * @param key - Key of stored specs
+   * @param key - Primary key of stored specs
+   * @param field - Secondary key of stored specs
    * @param specs - New specs to store
    */
-  set(key: string, specs: ConfigSpecs): Promise<void>;
+  set(key: string, field: string, specs: ConfigSpecs): Promise<void>;
   /**
    * Clears specs for a given key.
-   * @param key - Key of stored specs
+   * @param key - Primary key of stored specs
    */
   clear(key: string): Promise<void>;
+  /**
+   * Clears specs for a given key.
+   * @param key - Primary key of stored specs
+   * @param field - Secondary key of stored specs
+   */
+  clear(key: string, field: string): Promise<void>;
   /**
    * Clears all specs.
    */

--- a/src/utils/CacheHandler.ts
+++ b/src/utils/CacheHandler.ts
@@ -23,7 +23,7 @@ export default class CacheHandler {
     specs: ConfigSpecs
   ): Promise<void> {
     const cacheKey = CacheUtils.getCacheKey(sdkKey, options);
-    await this.cache.specs.set(cacheKey, specs);
+    await this.cache.specs.set(sdkKey, cacheKey, specs);
   }
 
   public async getSpecs(
@@ -31,15 +31,14 @@ export default class CacheHandler {
     options: ConfigSpecsOptions | undefined
   ): Promise<ConfigSpecs | null> {
     const cacheKey = CacheUtils.getCacheKey(sdkKey, options);
-    return await this.cache.specs.get(cacheKey);
+    return await this.cache.specs.get(sdkKey, cacheKey);
   }
 
   public async clearSpecs(...sdkKeys: string[]) {
     if (sdkKeys.length > 0) {
       await Promise.all(
         sdkKeys.map((sdkKey) => {
-          const cacheKey = CacheUtils.getCacheKey(sdkKey);
-          return this.cache.specs.clear(cacheKey);
+          return this.cache.specs.clear(sdkKey);
         })
       );
     } else {

--- a/tests/SpecsCachePlugin.test.ts
+++ b/tests/SpecsCachePlugin.test.ts
@@ -1,0 +1,77 @@
+import StatsigStorageExample from "../examples/StatsigStorageExample";
+import SpecsCache from "../src/SpecsCache";
+import StatsigOnPrem from "../src/StatsigOnPrem";
+import CacheUtils from "../src/utils/CacheUtils";
+import HashUtils from "../src/utils/HashUtils";
+
+describe("SpecsCachePlugin", () => {
+  const storage = new StatsigStorageExample();
+  const specsCache = new SpecsCache();
+  const statsig = new StatsigOnPrem(storage, { specsCache });
+
+  beforeAll(async () => {
+    await statsig.initialize();
+    await statsig.createGate("example-gate", {
+      targetApps: ["targetApp1"],
+      enabled: true,
+    });
+    await statsig.createConfig("example-config", {
+      defaultValue: {},
+      enabled: true,
+    });
+    await statsig.registerSDKKey("secret-key");
+  });
+
+  afterAll(async () => {
+    storage.clearAll();
+    await statsig.clearCache();
+  });
+
+  it("Cache config specs with default options", async () => {
+    const specs = await statsig.getConfigSpecs("secret-key");
+    expect(specs.dynamic_configs.length).toEqual(1);
+    expect(specs.feature_gates.length).toEqual(1);
+    expect(specs.hashed_sdk_keys_to_entities).toBeUndefined();
+
+    const cached = await specsCache.get(
+      "secret-key",
+      CacheUtils.getCacheKey("secret-key")
+    );
+    expect(cached).toEqual(specs);
+  });
+
+  it("Cache config specs with SSR options", async () => {
+    const options = { ssr: { targetApps: ["targetApp1"] } };
+    const specs = await statsig.getConfigSpecs("secret-key", options);
+    expect(specs.dynamic_configs.length).toEqual(1);
+    expect(specs.feature_gates.length).toEqual(1);
+    expect(specs.hashed_sdk_keys_to_entities).toEqual({
+      [HashUtils.hashString("targetApp1")]: {
+        gates: ["example-gate"],
+        configs: [],
+      },
+    });
+
+    const cached = await specsCache.get(
+      "secret-key",
+      CacheUtils.getCacheKey("secret-key", options)
+    );
+    expect(cached).toEqual(specs);
+  });
+
+  it("Clear cache for SDK key", async () => {
+    await specsCache.clear("secret-key");
+    const cachedDefault = await specsCache.get(
+      "secret-key",
+      CacheUtils.getCacheKey("secret-key")
+    );
+    const cachedSSR = await specsCache.get(
+      "secret-key",
+      CacheUtils.getCacheKey("secret-key", {
+        ssr: { targetApps: ["targetApp1"] },
+      })
+    );
+    expect(cachedDefault).toBeNull();
+    expect(cachedSSR).toBeNull();
+  });
+});


### PR DESCRIPTION
There is an issue where clearing specs cache for an SDK key does not clear specs that were loaded with `hashed_sdk_keys_to_entities` (SSR option).

Since the cache key is non-deterministic from the SDK key when using this option, we need to modify the `SpecsCacheInterface` to force caching using a primary key and secondary key. That way, the on-prem library can clear cache for an entire SDK key without needing to know all the associated cache keys.

Note that this is a breaking change! And may require migrating data in the underlying cache